### PR TITLE
Fixes for the Weather API lesson

### DIFF
--- a/lessons/fast-track/requests-weather/index.md
+++ b/lessons/fast-track/requests-weather/index.md
@@ -53,7 +53,7 @@ má podobu odpovědi s kódem `3xx`. Přímo tuto odpověď neuvidíte, protože
 knihovna `requests` ví, že je to přesměrování a proto automaticky půjde na
 adresu, kam vás server poslal.
 
-Ke každému číselnému kódu existuje i texotvý popis. Ty najdete třeba na
+Ke každému číselnému kódu existuje i textový popis. Ty najdete třeba na
 [Wikipedii](), nebo můžete použít <https://http.cat>.
 
 > [note]

--- a/runs/2019/brno-jaro-2019-pondeli/info.yml
+++ b/runs/2019/brno-jaro-2019-pondeli/info.yml
@@ -154,9 +154,7 @@ plan:
   materials:
   - title: Jak funguje internet
     lesson: fast-track/http
-  - title: Stažení předpovědi počasí (requests)
-    type: lesson
-    lesson: fast-track/requests-weather
+  - lesson: fast-track/requests-weather
   - title: JSON
     lesson: intro/json
 


### PR DESCRIPTION
- Typo fix
- Don't rename the lesson in the table of contents (people find that confusing). The defaults should be fine.

@mpavlase, these were reported by some of your students. Does this look OK :)